### PR TITLE
fixes incorrect 'stuck' event if sentinel is child of a flex/grid container

### DIFF
--- a/sticky-events.js
+++ b/sticky-events.js
@@ -181,6 +181,7 @@ function getSentinelPosition(stickyElement, sentinel, className) {
     case ClassName.SENTINEL_TOP:
       return {
         top: `calc(${stickyStyle.getPropertyValue('top')} * -1)`,
+        height: '0'
       };
 
     case ClassName.SENTINEL_BOTTOM:


### PR DESCRIPTION
essentially not having a height on the top sentinel, allowed a flex container or any extrinsic layout definition on the parent, to give the sentinel a height. when the top sentinel has a height, it's not going to report "stuck" properly. easy peasy fix. 