### PR TITLE
Use provided container for selecting sticky elements

### DIFF
--- a/sticky-events.js
+++ b/sticky-events.js
@@ -27,7 +27,7 @@ export default class StickyEvents {
   constructor({ container = document, enabled = true, stickySelector = '.sticky-events' } = {}) {
     this.container = container;
     this.observers = [];
-    this.stickyElements = Array.from(document.querySelectorAll(stickySelector));
+    this.stickyElements = Array.from(this.container.querySelectorAll(stickySelector));
     this.stickySelector = stickySelector;
     this.state = new Map();
 


### PR DESCRIPTION
Fix for [#20](https://github.com/ryanwalters/sticky-events/issues/20)